### PR TITLE
課題④-5.ユーザ一覧表示の実装

### DIFF
--- a/nagesen/src/components/Dashboard.vue
+++ b/nagesen/src/components/Dashboard.vue
@@ -6,17 +6,36 @@
     </div>
 
     <h1>ユーザ一覧</h1>
-    <p>課題４－３で対応のため未実装</p>
+    <ul>
+      <li class="sub">ユーザ名</li>
+      <li v-for="(user,index) in registeredUser" :key="index">
+        <div class="name">{{user.displayName}}</div>
+        <div>
+          <button class="wallet" @click="openWalletModal(user)">walletを見る</button>
+          <button class="wallet">送る</button>
+        </div>
+      </li>
+    </ul>
+
+    <wallet-modal v-if="showWallet" @from-child="closeWalletModal"></wallet-modal>
+
   </div>
 </template>
 
 <script>
+import WalletModal from './WalletModal.vue'
+
 export default {
   name: 'Dashboard',
+  components:{
+    WalletModal
+  },
   data(){
     return {
       displayName: '',
-      remaining: ''
+      remaining: '',
+      registeredUser:[],
+      showWallet: false
     }
   },
   created(){
@@ -25,6 +44,10 @@ export default {
       .then(() => {
         this.displayName = this.$store.getters.displayName;
         this.remaining = this.$store.getters.money;
+        //登録ユーザの情報を表示する
+        this.$store.dispatch('getRegisteredUser');
+        this.registeredUser = this.$store.getters.registeredUser;
+
       }).catch(() => {
         this.$router.push('/');
       });
@@ -32,6 +55,13 @@ export default {
   methods: {
     signOut() {
       this.$store.dispatch('signOutUser');
+    },
+    openWalletModal(user){
+      this.showWallet = true;
+      this.$store.commit('chengeFocusUser',user);
+    },    
+    closeWalletModal(){
+      this.showWallet = false;
     }
   }
 }
@@ -42,7 +72,7 @@ export default {
 <style scoped>
 
 .Dashboard{
-  width: 1000px;
+  width: 600px;
   margin: 0 auto;
 }
 
@@ -71,4 +101,28 @@ export default {
   background-color: #0086fb;
 }
 
+ul li{
+  display: flex;
+  justify-content:space-between;
+  list-style: none;
+}
+
+.sub{
+  font-weight: bold;
+  font-size: 20px;
+  
+}
+
+.name{
+  padding-left: 15px;
+}
+
+.wallet{
+  margin: 2px 3px;
+  padding: 5px 7px;
+  background-color: #1aa1b9;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 5px;
+}
 </style>

--- a/nagesen/src/components/Dashboard.vue
+++ b/nagesen/src/components/Dashboard.vue
@@ -8,7 +8,7 @@
     <h1>ユーザ一覧</h1>
     <ul>
       <li class="sub">ユーザ名</li>
-      <li v-for="(user,index) in registeredUser" :key="index">
+      <li v-for="(user,index) in registeredUsers" :key="index">
         <div class="name">{{user.displayName}}</div>
         <div>
           <button class="wallet" @click="openWalletModal(user)">walletを見る</button>
@@ -34,7 +34,7 @@ export default {
     return {
       displayName: '',
       remaining: '',
-      registeredUser:[],
+      registeredUsers:[],
       showWallet: false
     }
   },
@@ -45,8 +45,8 @@ export default {
         this.displayName = this.$store.getters.displayName;
         this.remaining = this.$store.getters.money;
         //登録ユーザの情報を表示する
-        this.$store.dispatch('getRegisteredUser');
-        this.registeredUser = this.$store.getters.registeredUser;
+        this.$store.dispatch('getRegisteredUsers');
+        this.registeredUsers = this.$store.getters.registeredUsers;
 
       }).catch(() => {
         this.$router.push('/');

--- a/nagesen/src/components/WalletModal.vue
+++ b/nagesen/src/components/WalletModal.vue
@@ -1,0 +1,78 @@
+<template>
+  <div id="overlay" @click="closeModal">
+    <div id="content" @click="stopEvent">
+      <p>{{user.displayName}}さんの残高</p>
+      <p>{{user.money}}</p>
+      <div class="bottom">
+        <button @click="closeModal">close</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'WalletModal',
+  data(){
+    return {
+      user:''
+    }
+  },
+  created(){
+    this.user = this.$store.getters.focusUser;
+  },
+  methods: {
+    closeModal(){
+      this.$emit('from-child')
+    },
+    stopEvent(event){
+      event.stopPropagation()
+    }
+  }
+}
+</script>
+
+<style scoped>
+
+/* モーダルウィンドウ設定 */
+#content{
+  z-index:10;
+  width:200px;
+  height:100px;
+  background:#fff;
+}
+
+#overlay{
+  z-index:1;
+  position:fixed;
+  top:0;
+  left:0;
+  width:100%;
+  height:100%;
+  background-color:rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#content p{
+  margin: 8px;
+}
+
+.bottom{
+  background-color: #c9cac9;
+  width: 200px;
+  height: 40px;
+}
+
+.bottom button{
+  padding: 5px;
+  margin-top: 10px;
+  margin-left: 130px;
+  background-color: #db2341;
+  color: #FFFFFF;
+  border: none;
+  border-radius: 5px;
+}
+
+</style>

--- a/nagesen/src/store/index.js
+++ b/nagesen/src/store/index.js
@@ -12,13 +12,13 @@ export default new Vuex.Store({
       money:'',
       email:''
     },
-    registeredUser:[],
+    registeredUsers:[],
     focusUser:''
   },
   getters: {
     displayName(state) { return state.loginUser.displayName},
     money(state) { return state.loginUser.money},
-    registeredUser(state) { return state.registeredUser},
+    registeredUsers(state) { return state.registeredUsers},
     focusUser(state)  { return state.focusUser}
   },
   mutations: {
@@ -102,14 +102,14 @@ export default new Vuex.Store({
         })
     },
     //登録ユーザの情報を取得する
-    getRegisteredUser(){
+    getRegisteredUsers(){
       //配列の初期化
-      this.state.registeredUser.splice(0,this.state.registeredUser.length);
+      this.state.registeredUsers.splice(0,this.state.registeredUsers.length);
       //DBからログインユーザ以外の登録ユーザデータを保存
       firebase.firestore().collection('wallet').get().then((querySnapshot) => {
         querySnapshot.forEach((doc) => {
             if(this.state.loginUser.email !== doc.data().email){
-              this.state.registeredUser.push(doc.data());
+              this.state.registeredUsers.push(doc.data());
             }
         });
       });

--- a/nagesen/src/store/index.js
+++ b/nagesen/src/store/index.js
@@ -9,14 +9,22 @@ export default new Vuex.Store({
   state: {
     loginUser:{
       displayName:'',
-      money:''
-    }
+      money:'',
+      email:''
+    },
+    registeredUser:[],
+    focusUser:''
   },
   getters: {
     displayName(state) { return state.loginUser.displayName},
-    money(state) { return state.loginUser.money}
+    money(state) { return state.loginUser.money},
+    registeredUser(state) { return state.registeredUser},
+    focusUser(state)  { return state.focusUser}
   },
   mutations: {
+    chengeFocusUser(state,user){
+      state.focusUser = user;
+    }
   },
   actions: {
     //新規登録画面でのユーザ登録処理
@@ -56,6 +64,7 @@ export default new Vuex.Store({
         firebase.auth().onAuthStateChanged((user) => {
           if(user){
             this.state.loginUser.displayName = user.displayName;
+            this.state.loginUser.email = user.email;
             //ログインユーザemailからＤＢ検索
             firebase.firestore().collection('wallet').where('email','==',user.email).get()
               .then(snapshot => {
@@ -91,6 +100,19 @@ export default new Vuex.Store({
         .catch((error) => {
           console.log('ログアウトエラー：　'　+ error.message);
         })
+    },
+    //登録ユーザの情報を取得する
+    getRegisteredUser(){
+      //配列の初期化
+      this.state.registeredUser.splice(0,this.state.registeredUser.length);
+      //DBからログインユーザ以外の登録ユーザデータを保存
+      firebase.firestore().collection('wallet').get().then((querySnapshot) => {
+        querySnapshot.forEach((doc) => {
+            if(this.state.loginUser.email !== doc.data().email){
+              this.state.registeredUser.push(doc.data());
+            }
+        });
+      });
     }
   },
   modules: {


### PR DESCRIPTION
【編集ファイル】　コミットNo 719446e
nagesen/src/components/Dashboard.vue
nagesen/src/store/index.js
nagesen/src/components/WalletModal.vue　　※新規追加

【内容】
以下、実装の概要とポイントをまとめてみました。

⇒ダッシュボードに、自分以外の登録ユーザが一覧表示
actionに、getRegisteredUserメソッドを追加し、登録ユーザ情報をfirestoreから取得しています。
ダッシュボード遷移時（created内）にて、実行しています。
※vuexのstate内にregisteredUserを新たに定義し、登録ユーザ情報をvuexにて管理・利用しています。
※vuexのstate内にloginUser.emailを新たに定義し、登録ユーザ情報からログインユーザを除外するのに利用しています（store/index.js：111行目）


⇒ユーザを選択し、そのユーザーのウォレットを確認可能
モーダルウィンドウ用コンポーネントWalletModal.vueを追加しました。
Dashboard.vueのdataに新たにshowWallet:falseを定義して、v-ifにより、表示を制御しています。
※vuexのstate内にfocusUserを新たに定義し、「walletを見る」ボタンが押された際に表示する用の情報をvuexで管理しています。

モーダルウィンドウ参考URL：https://reffect.co.jp/vue/understand-component-by-moda-window


